### PR TITLE
Standardize version property names

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <version.datawave>7.0.0</version.datawave>
         <version.in-memory-accumulo>4.0.0</version.in-memory-accumulo>
-        <version.microservice.starter>4.0.0</version.microservice.starter>
+        <version.starter>4.0.0</version.starter>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -60,12 +60,12 @@
             <dependency>
                 <groupId>gov.nsa.datawave.microservice</groupId>
                 <artifactId>spring-boot-starter-datawave</artifactId>
-                <version>${version.microservice.starter}</version>
+                <version>${version.starter}</version>
             </dependency>
             <dependency>
                 <groupId>gov.nsa.datawave.microservice</groupId>
                 <artifactId>spring-boot-starter-datawave</artifactId>
-                <version>${version.microservice.starter}</version>
+                <version>${version.starter}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,8 @@
     </scm>
     <properties>
         <version.datawave>7.0.0</version.datawave>
+        <version.datawave.starter>4.0.0</version.datawave.starter>
         <version.in-memory-accumulo>4.0.0</version.in-memory-accumulo>
-        <version.starter>4.0.0</version.starter>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -60,12 +60,12 @@
             <dependency>
                 <groupId>gov.nsa.datawave.microservice</groupId>
                 <artifactId>spring-boot-starter-datawave</artifactId>
-                <version>${version.starter}</version>
+                <version>${version.datawave.starter}</version>
             </dependency>
             <dependency>
                 <groupId>gov.nsa.datawave.microservice</groupId>
                 <artifactId>spring-boot-starter-datawave</artifactId>
-                <version>${version.starter}</version>
+                <version>${version.datawave.starter}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
This PR is part of the effort to standardize version property names across all repos to make it easier to update the version of an artifact across the board.

Related to: [DW Issue 2436](https://github.com/NationalSecurityAgency/datawave/issues/2436)